### PR TITLE
Switch to Redox-compatible termion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ name = "liner_test"
 [dependencies]
 
 [dependencies.termion]
-git = "https://github.com/Ticki/termion.git"
+git = "https://github.com/jackpot51/termion.git"
 features = ["nightly"]


### PR DESCRIPTION
Pending the merge of https://github.com/ticki/termion/pull/25, I have changes in my fork that allow compilation of termion on Redox