### PR TITLE
Improve handling of character counts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ name = "liner"
 name = "liner_test"
 
 [dependencies]
+unicode-width = "0.1.*"
 
 [dependencies.termion]
 git = "https://github.com/Ticki/termion.git"

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,4 +1,5 @@
 use termion::TermWrite;
+use unicode_width::UnicodeWidthStr;
 use std::io::{self, Write};
 use std::iter::FromIterator;
 
@@ -128,6 +129,10 @@ impl Buffer {
         s.len()
     }
 
+    pub fn width(&self) -> usize {
+        self.range_width(0, self.num_chars())
+    }
+
     pub fn char_before(&self, cursor: usize) -> Option<char> {
         if cursor == 0 {
             None
@@ -167,6 +172,10 @@ impl Buffer {
 
     pub fn range_chars(&self, start: usize, end: usize) -> Vec<char> {
         self.data[start..end].iter().cloned().collect()
+    }
+
+    pub fn range_width(&self, start: usize, end: usize) -> usize {
+        self.range(start, end)[..].width()
     }
 
     pub fn chars(&self) -> ::std::slice::Iter<char> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate termion;
+extern crate unicode_width;
 
 mod event;
 pub use event::*;

--- a/src/util.rs
+++ b/src/util.rs
@@ -34,3 +34,14 @@ pub fn find_longest_common_prefix<T: Clone + Eq>(among: &[Vec<T>]) -> Option<Vec
 
     None
 }
+
+fn is_ascii_letter(c: char) -> bool {
+    (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+pub fn remove_csi_codes(input: &str) -> String {
+    // XXX: better way to do this
+    input.split('\x1B')
+        .flat_map(|x| x.chars().skip_while(|&c| c != '?' && !is_ascii_letter(c)).skip(1))
+        .collect()
+}


### PR DESCRIPTION
- properly handle zero/single/double-width characters
- don't count CSI escape codes as characters in the prompt

This fixes a problem where liner would have unexpected behaviour if the prompt contained coloured text.

This also allows use of wide character sets such as CJK (eg. `안녕`).

Fixes #8.