### PR TITLE
support undo/redo with truncate

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -192,7 +192,8 @@ impl Buffer {
     }
 
     pub fn truncate(&mut self, num: usize) {
-        self.data.truncate(num);
+        let end = self.data.len();
+        self.remove(num, end);
     }
 
     pub fn print<W>(&self, out: &mut W) -> io::Result<()>
@@ -212,5 +213,85 @@ impl Buffer {
         for (i, &c) in text.iter().enumerate() {
             self.data.insert(start + i, c)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_insert() {
+        let mut buf = Buffer::new();
+        buf.insert(0, &['a', 'b', 'c', 'd', 'e', 'f', 'g']);
+        assert_eq!(String::from(buf), "abcdefg");
+    }
+
+    #[test]
+    fn test_truncate_empty() {
+        let mut buf = Buffer::new();
+        buf.truncate(0);
+        assert_eq!(String::from(buf), "");
+    }
+
+    #[test]
+    fn test_truncate_all() {
+        let mut buf = Buffer::new();
+        buf.insert(0, &['a', 'b', 'c', 'd', 'e', 'f', 'g']);
+        buf.truncate(0);
+        assert_eq!(String::from(buf), "");
+    }
+
+    #[test]
+    fn test_truncate_end() {
+        let mut buf = Buffer::new();
+        buf.insert(0, &['a', 'b', 'c', 'd', 'e', 'f', 'g']);
+        let end = buf.num_chars();
+        buf.truncate(end);
+        assert_eq!(String::from(buf), "abcdefg");
+    }
+
+    #[test]
+    fn test_truncate_part() {
+        let mut buf = Buffer::new();
+        buf.insert(0, &['a', 'b', 'c', 'd', 'e', 'f', 'g']);
+        buf.truncate(3);
+        assert_eq!(String::from(buf), "abc");
+    }
+
+    #[test]
+    fn test_truncate_empty_undo() {
+        let mut buf = Buffer::new();
+        buf.truncate(0);
+        buf.undo();
+        assert_eq!(String::from(buf), "");
+    }
+
+    #[test]
+    fn test_truncate_all_then_undo() {
+        let mut buf = Buffer::new();
+        buf.insert(0, &['a', 'b', 'c', 'd', 'e', 'f', 'g']);
+        buf.truncate(0);
+        buf.undo();
+        assert_eq!(String::from(buf), "abcdefg");
+    }
+
+    #[test]
+    fn test_truncate_end_then_undo() {
+        let mut buf = Buffer::new();
+        buf.insert(0, &['a', 'b', 'c', 'd', 'e', 'f', 'g']);
+        let end = buf.num_chars();
+        buf.truncate(end);
+        buf.undo();
+        assert_eq!(String::from(buf), "abcdefg");
+    }
+
+    #[test]
+    fn test_truncate_part_then_undo() {
+        let mut buf = Buffer::new();
+        buf.insert(0, &['a', 'b', 'c', 'd', 'e', 'f', 'g']);
+        buf.truncate(3);
+        buf.undo();
+        assert_eq!(String::from(buf), "abcdefg");
     }
 }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -647,6 +647,19 @@ mod tests {
     }
 
     #[test]
+    /// test undoing delete_all_after_cursor
+    fn delete_all_after_cursor_undo() {
+        let mut context = Context::new();
+        let out = Vec::new();
+        let mut ed = Editor::new(out, "prompt".to_owned(), &mut context).unwrap();
+        ed.insert_str_after_cursor("delete all of this").unwrap();
+        ed.move_cursor_to_start_of_line().unwrap();
+        ed.delete_all_after_cursor().unwrap();
+        ed.undo().unwrap();
+        assert_eq!(String::from(ed), "delete all of this");
+    }
+
+    #[test]
     fn enter_is_done() {
         let mut context = Context::new();
         let out = Vec::new();

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -560,7 +560,11 @@ impl<'a, W: Write> Editor<'a, W> {
         let buf_width = buf.width();
         let new_prompt_and_buffer_width = buf_width + self.prompt_width;
 
-        let (w, _) = try!(termion::terminal_size());
+        let (w, _) =
+            // when testing hardcode terminal size values
+            if cfg!(test) { (80, 24) }
+            // otherwise pull values from termion
+            else { try!(termion::terminal_size()) };
         let w = w as usize;
         let new_num_lines = (new_prompt_and_buffer_width + w) / w;
 


### PR DESCRIPTION
Prior to this patch, typing some text, moving to the start of the line,
then deleting until the end of the line and attempting to undo will
cause a panic. This is because the truncate() operation did not update
the undo list. This has been corrected.