### PR TITLE
refactor Emacs key bindings behind generic KeyMap trait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 target
 Cargo.lock
 history
+
+# vim swap files
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,6 +3,7 @@ use termion::input::TermRead;
 use termion::raw::{IntoRawMode, RawTerminal};
 
 use super::*;
+use keymap;
 
 /// The default for `Context.word_fn`.
 pub fn get_buffer_words(buf: &Buffer) -> Vec<(usize, usize)> {
@@ -64,7 +65,7 @@ impl Context {
         let res = {
             let stdout = stdout().into_raw_mode().unwrap();
             let ed = try!(Editor::new(stdout, prompt.into(), self));
-            Self::handle_keys(ed, handler)
+            Self::handle_keys(keymap::Emacs::new(ed), handler)
         };
 
         self.revert_all_history();

--- a/src/context.rs
+++ b/src/context.rs
@@ -62,22 +62,27 @@ impl Context {
                                       mut handler: &mut EventHandler<RawTerminal<Stdout>>)
                                       -> io::Result<String> {
         let res = {
-            let stdin = stdin();
-
             let stdout = stdout().into_raw_mode().unwrap();
-            let mut ed = try!(Editor::new(stdout, prompt.into(), self));
-
-            for c in stdin.keys() {
-                if try!(ed.handle_key(c.unwrap(), handler)) {
-                    break;
-                }
-            }
-
-            Ok(ed.into())
+            let ed = try!(Editor::new(stdout, prompt.into(), self));
+            Self::handle_keys(ed, handler)
         };
 
         self.revert_all_history();
         res
+    }
+
+    fn handle_keys(mut ed: Editor<RawTerminal<Stdout>>,
+                   mut handler: &mut EventHandler<RawTerminal<Stdout>>)
+    -> io::Result<String>
+    {
+        let stdin = stdin();
+        for c in stdin.keys() {
+            if try!(ed.handle_key(c.unwrap(), handler)) {
+                break;
+            }
+        }
+
+        Ok(ed.into())
     }
 
     pub fn revert_all_history(&mut self) {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Stdout, stdout, stdin};
+use std::io::{self, Stdout, stdout, stdin, Write};
 use termion::input::TermRead;
 use termion::raw::{IntoRawMode, RawTerminal};
 
@@ -71,18 +71,20 @@ impl Context {
         res
     }
 
-    fn handle_keys(mut ed: Editor<RawTerminal<Stdout>>,
-                   mut handler: &mut EventHandler<RawTerminal<Stdout>>)
+    fn handle_keys<'a, T, W: Write, M: KeyMap<'a, W, T>>(
+        mut keymap: M,
+        mut handler: &mut EventHandler<W>)
     -> io::Result<String>
+        where String: From<M>
     {
         let stdin = stdin();
         for c in stdin.keys() {
-            if try!(ed.handle_key(c.unwrap(), handler)) {
+            if try!(keymap.handle_key(c.unwrap(), handler)) {
                 break;
             }
         }
 
-        Ok(ed.into())
+        Ok(keymap.into())
     }
 
     pub fn revert_all_history(&mut self) {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -178,22 +178,20 @@ impl<'a, W: Write> Editor<'a, W> {
 
     pub fn handle_key_emacs(&mut self, key: Key) -> io::Result<()> {
         match key {
-            Key::Char(c) => try!(self.insert_after_cursor(c)),
-            Key::Alt(c) => try!(self.handle_alt_key(c)),
-            Key::Ctrl(c) => try!(self.handle_ctrl_key(c)),
-            Key::Left => try!(self.move_cursor_left(1)),
-            Key::Right => try!(self.move_cursor_right(1)),
-            Key::Up => try!(self.move_up()),
-            Key::Down => try!(self.move_down()),
-            Key::Home => try!(self.move_cursor_to_start_of_line()),
-            Key::End => try!(self.move_cursor_to_end_of_line()),
-            Key::Backspace => try!(self.delete_before_cursor()),
-            Key::Delete => try!(self.delete_after_cursor()),
-            Key::Null => {}
-            _ => {}
+            Key::Char(c) => self.insert_after_cursor(c),
+            Key::Alt(c) => self.handle_alt_key(c),
+            Key::Ctrl(c) => self.handle_ctrl_key(c),
+            Key::Left => self.move_cursor_left(1),
+            Key::Right => self.move_cursor_right(1),
+            Key::Up => self.move_up(),
+            Key::Down => self.move_down(),
+            Key::Home => self.move_cursor_to_start_of_line(),
+            Key::End => self.move_cursor_to_end_of_line(),
+            Key::Backspace => self.delete_before_cursor(),
+            Key::Delete => self.delete_after_cursor(),
+            Key::Null => Ok(()),
+            _ => Ok(()),
         }
-
-        Ok(())
     }
 
     fn handle_ctrl_key(&mut self, c: char) -> io::Result<()> {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -7,7 +7,6 @@ use Context;
 use Buffer;
 use event::*;
 use util;
-use KeyMap;
 
 /// Represents the position of the cursor relative to words in the buffer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -633,16 +632,6 @@ impl<'a, W: Write> From<Editor<'a, W>> for String {
                 _ => ed.new_buf,
             }
             .into()
-    }
-}
-
-impl<'a, W: Write> KeyMap<'a, W, Editor<'a, W>> for Editor<'a, W> {
-    fn handle_key(&mut self, key: Key, handler: &mut EventHandler<W>) -> io::Result<bool> {
-        self.handle_key(key, handler)
-    }
-
-    fn editor(&mut self) ->  &mut Editor<'a, W> {
-        self
     }
 }
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -176,11 +176,9 @@ impl<'a, W: Write> Editor<'a, W> {
         Ok(done)
     }
 
-    pub fn handle_key_emacs(&mut self, key: Key) -> io::Result<()> {
+    pub fn handle_key_common(&mut self, key: Key) -> io::Result<()> {
         match key {
-            Key::Char(c) => self.insert_after_cursor(c),
-            Key::Alt(c) => self.handle_alt_key(c),
-            Key::Ctrl(c) => self.handle_ctrl_key(c),
+            Key::Ctrl('l') => self.clear(),
             Key::Left => self.move_cursor_left(1),
             Key::Right => self.move_cursor_right(1),
             Key::Up => self.move_up(),
@@ -191,6 +189,15 @@ impl<'a, W: Write> Editor<'a, W> {
             Key::Delete => self.delete_after_cursor(),
             Key::Null => Ok(()),
             _ => Ok(()),
+        }
+    }
+
+    pub fn handle_key_emacs(&mut self, key: Key) -> io::Result<()> {
+        match key {
+            Key::Char(c) => self.insert_after_cursor(c),
+            Key::Alt(c) => self.handle_alt_key(c),
+            Key::Ctrl(c) => self.handle_ctrl_key(c),
+            _ => self.handle_key_common(key),
         }
     }
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -501,7 +501,11 @@ impl<'a, W: Write> Editor<'a, W> {
         let buf_width = buf.width();
         let new_prompt_and_buffer_width = buf_width + self.prompt_width;
 
-        let (w, _) = try!(termion::terminal_size());
+        let (w, _) =
+            // when testing hardcode terminal size values
+            if cfg!(test) { (80, 24) }
+            // otherwise pull values from termion
+            else { try!(termion::terminal_size()) };
         let w = w as usize;
         let new_num_lines = (new_prompt_and_buffer_width + w) / w;
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -7,6 +7,7 @@ use Context;
 use Buffer;
 use event::*;
 use util;
+use KeyMap;
 
 /// Represents the position of the cursor relative to words in the buffer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -632,6 +633,16 @@ impl<'a, W: Write> From<Editor<'a, W>> for String {
                 _ => ed.new_buf,
             }
             .into()
+    }
+}
+
+impl<'a, W: Write> KeyMap<'a, W, Editor<'a, W>> for Editor<'a, W> {
+    fn handle_key(&mut self, key: Key, handler: &mut EventHandler<W>) -> io::Result<bool> {
+        self.handle_key(key, handler)
+    }
+
+    fn editor(&mut self) ->  &mut Editor<'a, W> {
+        self
     }
 }
 

--- a/src/keymap/emacs.rs
+++ b/src/keymap/emacs.rs
@@ -14,11 +14,60 @@ impl<'a, W: Write> Emacs<'a, W> {
             ed: ed,
         }
     }
+
+    fn handle_ctrl_key(&mut self, c: char) -> io::Result<()> {
+        match c {
+            'l' => self.ed.clear(),
+            'a' => self.ed.move_cursor_to_start_of_line(),
+            'e' => self.ed.move_cursor_to_end_of_line(),
+            'b' => self.ed.move_cursor_left(1),
+            'f' => self.ed.move_cursor_right(1),
+            'd' => self.ed.delete_after_cursor(),
+            'p' => self.ed.move_up(),
+            'n' => self.ed.move_down(),
+            'u' => self.ed.delete_all_before_cursor(),
+            'k' => self.ed.delete_all_after_cursor(),
+            'w' => self.ed.delete_word_before_cursor(true),
+            'x' => {
+                try!(self.ed.undo());
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn handle_alt_key(&mut self, c: char) -> io::Result<()> {
+        match c {
+            '<' => self.ed.move_to_start_of_history(),
+            '>' => self.ed.move_to_end_of_history(),
+            '\x7F' => self.ed.delete_word_before_cursor(true),
+            'r' => {
+                try!(self.ed.revert());
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+
 }
 
 impl<'a, W: Write> KeyMap<'a, W, Emacs<'a, W>> for Emacs<'a, W> {
     fn handle_key_core(&mut self, key: Key) -> io::Result<()> {
-        self.ed.handle_key_emacs(key)
+        match key {
+            Key::Char(c) => self.ed.insert_after_cursor(c),
+            Key::Alt(c) => self.handle_alt_key(c),
+            Key::Ctrl(c) => self.handle_ctrl_key(c),
+            Key::Left => self.ed.move_cursor_left(1),
+            Key::Right => self.ed.move_cursor_right(1),
+            Key::Up => self.ed.move_up(),
+            Key::Down => self.ed.move_down(),
+            Key::Home => self.ed.move_cursor_to_start_of_line(),
+            Key::End => self.ed.move_cursor_to_end_of_line(),
+            Key::Backspace => self.ed.delete_before_cursor(),
+            Key::Delete => self.ed.delete_after_cursor(),
+            Key::Null => Ok(()),
+            _ => Ok(()),
+        }
     }
 
     fn editor(&mut self) ->  &mut Editor<'a, W> {
@@ -29,5 +78,86 @@ impl<'a, W: Write> KeyMap<'a, W, Emacs<'a, W>> for Emacs<'a, W> {
 impl<'a, W: Write> From<Emacs<'a, W>> for String {
     fn from(emacs: Emacs<'a, W>) -> String {
         emacs.ed.into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use termion::event::Key;
+    use Context;
+    use Editor;
+    use KeyMap;
+    use std::io::Write;
+
+    macro_rules! simulate_keys {
+        ($keymap:ident, $keys:expr) => {{
+            simulate_keys(&mut $keymap, $keys.into_iter())
+        }}
+    }
+
+    fn simulate_keys<'a, 'b, W: Write, T, M: KeyMap<'a, W, T>, I>(keymap: &mut M, keys: I) -> bool
+        where I: Iterator<Item=&'b Key>
+    {
+        for k in keys {
+            if keymap.handle_key(*k, &mut |_| {}).unwrap() {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    #[test]
+    fn enter_is_done() {
+        let mut context = Context::new();
+        let out = Vec::new();
+        let ed = Editor::new(out, "prompt".to_owned(), &mut context).unwrap();
+        let mut map = Emacs::new(ed);
+        map.ed.insert_str_after_cursor("done").unwrap();
+        assert_eq!(map.ed.cursor(), 4);
+
+        assert!(simulate_keys!(map, [
+            Key::Char('\n'),
+        ]));
+
+        assert_eq!(map.ed.cursor(), 4);
+        assert_eq!(String::from(map), "done");
+    }
+
+    #[test]
+    fn move_cursor_left() {
+        let mut context = Context::new();
+        let out = Vec::new();
+        let ed = Editor::new(out, "prompt".to_owned(), &mut context).unwrap();
+        let mut map = Emacs::new(ed);
+        map.editor().insert_str_after_cursor("let").unwrap();
+        assert_eq!(map.ed.cursor(), 3);
+
+        simulate_keys!(map, [
+            Key::Left,
+            Key::Char('f'),
+        ]);
+
+        assert_eq!(map.ed.cursor(), 3);
+        assert_eq!(String::from(map), "left");
+    }
+
+    #[test]
+    fn cursor_movement() {
+        let mut context = Context::new();
+        let out = Vec::new();
+        let ed = Editor::new(out, "prompt".to_owned(), &mut context).unwrap();
+        let mut map = Emacs::new(ed);
+        map.ed.insert_str_after_cursor("right").unwrap();
+        assert_eq!(map.ed.cursor(), 5);
+
+        simulate_keys!(map, [
+            Key::Left,
+            Key::Left,
+            Key::Right,
+        ]);
+
+        assert_eq!(map.ed.cursor(), 4);
     }
 }

--- a/src/keymap/emacs.rs
+++ b/src/keymap/emacs.rs
@@ -1,0 +1,34 @@
+use std::io::{self, Write};
+use termion::event::Key;
+
+use KeyMap;
+use Editor;
+use event::EventHandler;
+
+pub struct Emacs<'a, W: Write> {
+    ed: Editor<'a, W>,
+}
+
+impl<'a, W: Write> Emacs<'a, W> {
+    pub fn new(ed: Editor<'a, W>) -> Self {
+        Emacs {
+            ed: ed,
+        }
+    }
+}
+
+impl<'a, W: Write> KeyMap<'a, W, Emacs<'a, W>> for Emacs<'a, W> {
+    fn handle_key(&mut self, key: Key, handler: &mut EventHandler<W>) -> io::Result<bool> {
+        self.ed.handle_key(key, handler)
+    }
+
+    fn editor(&mut self) ->  &mut Editor<'a, W> {
+        &mut self.ed
+    }
+}
+
+impl<'a, W: Write> From<Emacs<'a, W>> for String {
+    fn from(emacs: Emacs<'a, W>) -> String {
+        emacs.ed.into()
+    }
+}

--- a/src/keymap/emacs.rs
+++ b/src/keymap/emacs.rs
@@ -3,7 +3,6 @@ use termion::event::Key;
 
 use KeyMap;
 use Editor;
-use event::EventHandler;
 
 pub struct Emacs<'a, W: Write> {
     ed: Editor<'a, W>,
@@ -18,8 +17,8 @@ impl<'a, W: Write> Emacs<'a, W> {
 }
 
 impl<'a, W: Write> KeyMap<'a, W, Emacs<'a, W>> for Emacs<'a, W> {
-    fn handle_key(&mut self, key: Key, handler: &mut EventHandler<W>) -> io::Result<bool> {
-        self.ed.handle_key(key, handler)
+    fn handle_key_core(&mut self, key: Key) -> io::Result<()> {
+        self.ed.handle_key_emacs(key)
     }
 
     fn editor(&mut self) ->  &mut Editor<'a, W> {

--- a/src/keymap/mod.rs
+++ b/src/keymap/mod.rs
@@ -7,3 +7,6 @@ pub trait KeyMap<'a, W: Write, T> : From<T> {
     fn handle_key(&mut self, key: Key, handler: &mut EventHandler<W>) -> io::Result<bool>;
     fn editor(&mut self) -> &mut Editor<'a, W>;
 }
+
+pub mod emacs;
+pub use emacs::Emacs;

--- a/src/keymap/mod.rs
+++ b/src/keymap/mod.rs
@@ -1,11 +1,35 @@
 use std::io::{self, Write};
 use termion::event::Key;
 use Editor;
-use event::EventHandler;
+use event::*;
 
 pub trait KeyMap<'a, W: Write, T> : From<T> {
-    fn handle_key(&mut self, key: Key, handler: &mut EventHandler<W>) -> io::Result<bool>;
+    fn handle_key_core(&mut self, key: Key) -> io::Result<()>;
     fn editor(&mut self) -> &mut Editor<'a, W>;
+
+    fn handle_key(&mut self, key: Key, handler: &mut EventHandler<W>) -> io::Result<bool> {
+        let mut done = false;
+
+        handler(Event::new(self.editor(), EventKind::BeforeKey(key)));
+
+        match key {
+            Key::Char('\t') => try!(self.editor().complete(handler)),
+            Key::Char('\n') => {
+                try!(self.editor().handle_newline());
+                done = true;
+            }
+            _ => {
+                try!(self.handle_key_core(key));
+                self.editor().skip_completions_hint();
+            }
+        };
+
+        handler(Event::new(self.editor(), EventKind::AfterKey(key)));
+
+        try!(self.editor().flush());
+
+        Ok(done)
+    }
 }
 
 pub mod emacs;

--- a/src/keymap/mod.rs
+++ b/src/keymap/mod.rs
@@ -1,0 +1,9 @@
+use std::io::{self, Write};
+use termion::event::Key;
+use Editor;
+use event::EventHandler;
+
+pub trait KeyMap<'a, W: Write, T> : From<T> {
+    fn handle_key(&mut self, key: Key, handler: &mut EventHandler<W>) -> io::Result<bool>;
+    fn editor(&mut self) -> &mut Editor<'a, W>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,9 @@ pub use buffer::*;
 mod history;
 pub use history::*;
 
+mod keymap;
+pub use keymap::*;
+
 mod util;
 
 #[cfg(test)]


### PR DESCRIPTION
I have added a KeyMap trait which is designed to handle key press events and map them to Editor commands. This decouples the Editor object from the key mapping. Additional key bindings can be created by implementing KeyMap potentially without changing Editor at all. This design was developed while implementing Vi keybindings.