### PR TITLE
enhance Vi KeyMap with most Vi movement commands

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -500,6 +500,12 @@ impl<'a, W: Write> Editor<'a, W> {
         cur_buf!(self)
     }
 
+    ///  Returns a mutable reference to the current buffer being edited.
+    /// This may be the new buffer or a buffer from history.
+    pub fn current_buffer_mut(&mut self) -> &mut Buffer {
+        cur_buf_mut!(self)
+    }
+
     /// Deletes the displayed prompt and buffer, replacing them with the current prompt and buffer
     pub fn print_current_buffer(&mut self, move_cursor_to_end_of_line: bool) -> io::Result<()> {
         let buf = cur_buf!(self);

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -455,6 +455,16 @@ impl<'a, W: Write> Editor<'a, W> {
         self.print_current_buffer(false)
     }
 
+    /// Deletes every character from the cursor until the given position, inclusive.
+    pub fn delete_until_inclusive(&mut self, position: usize) -> io::Result<()> {
+        {
+            let buf = cur_buf_mut!(self);
+            buf.remove(cmp::min(self.cursor, position), cmp::max(self.cursor + 1, position + 1));
+            self.cursor = cmp::min(self.cursor, position);
+        }
+        self.print_current_buffer(false)
+    }
+
     /// Moves the cursor to the left by `count` characters.
     /// The cursor will not go past the start of the buffer.
     pub fn move_cursor_left(&mut self, mut count: usize) -> io::Result<()> {
@@ -681,5 +691,18 @@ mod tests {
         ed.delete_until(1).unwrap();
         assert_eq!(ed.cursor, 1);
         assert_eq!(String::from(ed), "rt");
+    }
+
+    #[test]
+    fn delete_until_inclusive() {
+        let mut context = Context::new();
+        let out = Vec::new();
+        let mut ed = Editor::new(out, "prompt".to_owned(), &mut context).unwrap();
+        ed.insert_str_after_cursor("right").unwrap();
+        ed.cursor = 4;
+
+        ed.delete_until_inclusive(1).unwrap();
+        assert_eq!(ed.cursor, 1);
+        assert_eq!(String::from(ed), "r");
     }
 }

--- a/src/keymap/vi.rs
+++ b/src/keymap/vi.rs
@@ -2369,6 +2369,25 @@ mod tests {
     }
 
     #[test]
+    /// test delete word
+    fn delete_word() {
+        let mut context = Context::new();
+        let out = Vec::new();
+        let ed = Editor::new(out, "prompt".to_owned(), &mut context).unwrap();
+        let mut map = Vi::new(ed);
+        map.ed.insert_str_after_cursor("delete some words").unwrap();
+
+        simulate_keys!(map, [
+            Esc,
+            Char('0'),
+            Char('d'),
+            Char('w'),
+        ]);
+        assert_eq!(map.ed.cursor(), 0);
+        assert_eq!(String::from(map), "some words");
+    }
+
+    #[test]
     /// test changing a line
     fn change_line() {
         let mut context = Context::new();
@@ -2642,6 +2661,59 @@ mod tests {
     }
 
     #[test]
+    /// test change word
+    fn change_word() {
+        let mut context = Context::new();
+        let out = Vec::new();
+        let ed = Editor::new(out, "prompt".to_owned(), &mut context).unwrap();
+        let mut map = Vi::new(ed);
+        map.ed.insert_str_after_cursor("change some words").unwrap();
+
+        simulate_keys!(map, [
+            Esc,
+            Char('0'),
+            Char('c'),
+            Char('w'),
+            Char('t'),
+            Char('w'),
+            Char('e'),
+            Char('a'),
+            Char('k'),
+            Char(' '),
+        ]);
+        assert_eq!(String::from(map), "tweak some words");
+    }
+
+    #[test]
+    /// make sure the count is properly reset
+    fn test_count_reset_around_insert_and_delete() {
+        let mut context = Context::new();
+        let out = Vec::new();
+        let ed = Editor::new(out, "prompt".to_owned(), &mut context).unwrap();
+        let mut map = Vi::new(ed);
+        map.ed.insert_str_after_cursor("these are some words").unwrap();
+
+        simulate_keys!(map, [
+            Esc,
+            Char('0'),
+            Char('d'),
+            Char('3'),
+            Char('w'),
+            Char('i'),
+            Char('w'),
+            Char('o'),
+            Char('r'),
+            Char('d'),
+            Char('s'),
+            Char(' '),
+            Esc,
+            Char('l'),
+            Char('.'),
+        ]);
+        assert_eq!(String::from(map), "words words words");
+    }
+
+    #[test]
     /// undo with counts
     fn test_undo_with_counts() {
         let mut context = Context::new();
@@ -2682,6 +2754,31 @@ mod tests {
             Ctrl('r'),
         ]);
         assert_eq!(String::from(map), "abcde");
+    }
+
+    #[test]
+    /// test change word with 'gE'
+    fn change_word_ge_ws() {
+        let mut context = Context::new();
+        let out = Vec::new();
+        let ed = Editor::new(out, "prompt".to_owned(), &mut context).unwrap();
+        let mut map = Vi::new(ed);
+        map.ed.insert_str_after_cursor("change some words").unwrap();
+
+        simulate_keys!(map, [
+            Esc,
+            Char('c'),
+            Char('g'),
+            Char('E'),
+            Char('e'),
+            Char('t'),
+            Char('h'),
+            Char('i'),
+            Char('n'),
+            Char('g'),
+            Esc,
+        ]);
+        assert_eq!(String::from(map), "change something");
     }
 
     #[test]

--- a/src/keymap/vi.rs
+++ b/src/keymap/vi.rs
@@ -294,6 +294,16 @@ impl<'a, W: Write> Vi<'a, W> {
                 self.set_mode(Mode::Replace);
                 Ok(())
             }
+            Key::Char('D') => {
+                // update the last command state
+                self.last_insert = None;
+                self.last_command.clear();
+                self.last_command.push(key);
+                self.count = 0;
+                self.last_count = 0;
+
+                self.ed.delete_all_after_cursor()
+            }
             Key::Char('.') => {
                 // repeat the last command
                 self.count = match (self.count, self.last_count) {
@@ -1290,6 +1300,24 @@ mod tests {
             Char('.'),
         ]);
         assert_eq!(String::from(map), "ace");
+    }
+
+    #[test]
+    /// test delete until end of line
+    fn delete_until_end_shift_d() {
+        let mut context = Context::new();
+        let out = Vec::new();
+        let ed = Editor::new(out, "prompt".to_owned(), &mut context).unwrap();
+        let mut map = Vi::new(ed);
+        map.ed.insert_str_after_cursor("delete").unwrap();
+
+        simulate_keys!(map, [
+            Esc,
+            Char('0'),
+            Char('D'),
+        ]);
+        assert_eq!(map.ed.cursor(), 0);
+        assert_eq!(String::from(map), "");
     }
 
     #[test]


### PR DESCRIPTION
I rebased my vi branch to clean it up a bit. I decided to just include all of the remaining changes in a single pull request. Can break up if requested.

One open issue here is this code operates on chars not grapheme clusters so support for certain characters is probably broken. I'll also add a few notes below.

#6 