### PR TITLE
Fix removal of terminal escape codes

### DIFF
--- a/src/complete.rs
+++ b/src/complete.rs
@@ -56,10 +56,6 @@ impl Completer for FilenameCompleter {
             full_path = PathBuf::from(start_owned.clone());
         }
 
-        if full_path.is_relative() {
-            return vec![];
-        }
-
         let p;
         let start_name;
         let completing_dir;


### PR DESCRIPTION
Pull request form @jackpot51 fork.

Now, all terminal escape codes should be properly parsed.

Also removed the is_relative() check as it doesn't work on Redox.