### PR TITLE
support detection of ctrl-c and ctrl-d key presses

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -287,6 +287,11 @@ impl Buffer {
             false
         }
     }
+
+    /// Return true if the buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
If ctrl-c or ctrl-d is detected, an error will be returned to the caller. The example code has been updated to show how this works.

#4 