### PR TITLE
Pressing the right arrow key accepts autosuggestions

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -61,7 +61,7 @@ impl History {
 
     /// Go through the history and try to find a buffer which starts the same as the new buffer
     /// given to this function as argument.
-    pub fn get_first_match<'a, 'b>(&'a self, curr_position: Option<usize>, new_buff: &'b Buffer) -> Option<&'a Buffer> {
+    pub fn get_newest_match<'a, 'b>(&'a self, curr_position: Option<usize>, new_buff: &'b Buffer) -> Option<&'a Buffer> {
         let pos = curr_position.unwrap_or(self.buffers.len());
         for iter in (0..pos).rev() {
             if let Some(tested) = self.buffers.get(iter) {

--- a/src/keymap/emacs.rs
+++ b/src/keymap/emacs.rs
@@ -67,8 +67,12 @@ impl<'a, W: Write> KeyMap<'a, W, Emacs<'a, W>> for Emacs<'a, W> {
         }
     }
 
-    fn editor(&mut self) -> &mut Editor<'a, W> {
+    fn editor_mut(&mut self) ->  &mut Editor<'a, W> {
         &mut self.ed
+    }
+
+    fn editor(&self) ->  &Editor<'a, W> {
+        &self.ed
     }
 }
 
@@ -126,7 +130,7 @@ mod tests {
         let out = Vec::new();
         let ed = Editor::new(out, "prompt".to_owned(), &mut context).unwrap();
         let mut map = Emacs::new(ed);
-        map.editor().insert_str_after_cursor("let").unwrap();
+        map.editor_mut().insert_str_after_cursor("let").unwrap();
         assert_eq!(map.ed.cursor(), 3);
 
         simulate_keys!(map, [Key::Left, Key::Char('f')]);

--- a/src/keymap/vi.rs
+++ b/src/keymap/vi.rs
@@ -966,8 +966,12 @@ impl<'a, W: Write> KeyMap<'a, W, Vi<'a, W>> for Vi<'a, W> {
         }
     }
 
-    fn editor(&mut self) ->  &mut Editor<'a, W> {
+    fn editor_mut(&mut self) ->  &mut Editor<'a, W> {
         &mut self.ed
+    }
+
+    fn editor(&self) ->  &Editor<'a, W> {
+        &self.ed
     }
 }
 
@@ -1029,7 +1033,7 @@ mod tests {
         let out = Vec::new();
         let ed = Editor::new(out, "prompt".to_owned(), &mut context).unwrap();
         let mut map = Vi::new(ed);
-        map.editor().insert_str_after_cursor("let").unwrap();
+        map.editor_mut().insert_str_after_cursor("let").unwrap();
         assert_eq!(map.ed.cursor(), 3);
 
         simulate_keys!(map, [


### PR DESCRIPTION
Closes #37.

When an autosuggestion is showing, pressing the right arrow key will now accept the suggestion.

Changed `History.get_first_match()` to `History.get_newest_match()` to make what the method does more clear.