### PR TITLE
Move cursor to EOL for non-empty init buf

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -129,6 +129,10 @@ impl<'a, W: Write> Editor<'a, W> {
             no_eol: false,
         };
 
+        if !ed.new_buf.is_empty() {
+            ed.move_cursor_to_end_of_line()?;
+        }
+
         try!(ed.display());
         Ok(ed)
     }


### PR DESCRIPTION
This fixes my use case, for #70. I imagine you might want to think about perhaps another argument allowing the caller to specify the initial cursor position along with the initial buffer.