### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -4,7 +4,7 @@ use std::iter::FromIterator;
 use std::fmt::{self, Write as FmtWrite};
 
 /// A modification performed on a `Buffer`. These are used for the purpose of undo/redo.
-#[derive(Debug,Clone)]
+#[derive(Debug, Clone)]
 pub enum Action {
     Insert { start: usize, text: Vec<char> },
     Remove { start: usize, text: Vec<char> },
@@ -172,7 +172,10 @@ impl Buffer {
     }
 
     pub fn last_arg(&self) -> Option<&[char]> {
-        self.data.split(|&c| c == ' ').filter(|s| !s.is_empty()).last()
+        self.data
+            .split(|&c| c == ' ')
+            .filter(|s| !s.is_empty())
+            .last()
     }
 
     pub fn num_chars(&self) -> usize {
@@ -236,11 +239,17 @@ impl Buffer {
     }
 
     pub fn range_width(&self, start: usize, end: usize) -> Vec<usize> {
-        self.range(start, end).split('\n').map(|s| s.width()).collect()
+        self.range(start, end)
+            .split('\n')
+            .map(|s| s.width())
+            .collect()
     }
 
     pub fn lines(&self) -> Vec<String> {
-        self.data.split(|&c| c == '\n').map(|s| s.iter().cloned().collect()).collect()
+        self.data
+            .split(|&c| c == '\n')
+            .map(|s| s.iter().cloned().collect())
+            .collect()
     }
 
     pub fn chars(&self) -> ::std::slice::Iter<char> {
@@ -253,7 +262,8 @@ impl Buffer {
     }
 
     pub fn print<W>(&self, out: &mut W) -> io::Result<()>
-        where W: Write
+    where
+        W: Write,
     {
         let string: String = self.data.iter().cloned().collect();
         try!(out.write(string.as_bytes()));
@@ -271,7 +281,8 @@ impl Buffer {
     /// the other stopped.
     /// Used to implement autosuggestions.
     pub fn print_rest<W>(&self, out: &mut W, after: usize) -> io::Result<usize>
-        where W: Write
+    where
+        W: Write,
     {
         let string: String = self.data.iter().skip(after).cloned().collect();
         out.write(string.as_bytes())?;

--- a/src/complete.rs
+++ b/src/complete.rs
@@ -10,7 +10,9 @@ pub struct BasicCompleter {
 
 impl BasicCompleter {
     pub fn new<T: Into<String>>(prefixes: Vec<T>) -> BasicCompleter {
-        BasicCompleter { prefixes: prefixes.into_iter().map(|s| s.into()).collect() }
+        BasicCompleter {
+            prefixes: prefixes.into_iter().map(|s| s.into()).collect(),
+        }
     }
 }
 
@@ -30,7 +32,9 @@ pub struct FilenameCompleter {
 
 impl FilenameCompleter {
     pub fn new<T: Into<PathBuf>>(working_dir: Option<T>) -> Self {
-        FilenameCompleter { working_dir: working_dir.map(|p| p.into()) }
+        FilenameCompleter {
+            working_dir: working_dir.map(|p| p.into()),
+        }
     }
 }
 
@@ -65,8 +69,9 @@ impl Completer for FilenameCompleter {
         let completing_dir;
         match full_path.parent() {
             // XXX non-unix separaor
-            Some(parent) if start != "" && !start_owned.ends_with("/") &&
-                            !full_path.ends_with("..") => {
+            Some(parent)
+                if start != "" && !start_owned.ends_with("/") && !full_path.ends_with("..") =>
+            {
                 p = PathBuf::from(parent);
                 start_name = full_path
                     .file_name()
@@ -81,7 +86,6 @@ impl Completer for FilenameCompleter {
                 completing_dir = start == "" || start.ends_with("/") || full_path.ends_with("..");
             }
         }
-
 
         let read_dir = match p.read_dir() {
             Ok(x) => x,

--- a/src/context.rs
+++ b/src/context.rs
@@ -70,7 +70,7 @@ impl Context {
     pub fn read_line<P: Into<String>>(
         &mut self,
         prompt: P,
-        mut handler: &mut EventHandler<RawTerminal<Stdout>>,
+        handler: &mut EventHandler<RawTerminal<Stdout>>,
     ) -> io::Result<String> {
         self.read_line_with_init_buffer(prompt, handler, Buffer::new())
     }
@@ -88,7 +88,7 @@ impl Context {
     pub fn read_line_with_init_buffer<P: Into<String>, B: Into<Buffer>>(
         &mut self,
         prompt: P,
-        mut handler: &mut EventHandler<RawTerminal<Stdout>>,
+        handler: &mut EventHandler<RawTerminal<Stdout>>,
         buffer: B,
     ) -> io::Result<String> {
         let res = {
@@ -106,7 +106,7 @@ impl Context {
 
     fn handle_keys<'a, T, W: Write, M: KeyMap<'a, W, T>>(
         mut keymap: M,
-        mut handler: &mut EventHandler<W>,
+        handler: &mut EventHandler<W>,
     ) -> io::Result<String>
     where
         String: From<M>,

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -222,7 +222,7 @@ impl<'a, W: Write> Editor<'a, W> {
 
         // XXX wide character support
         let max_word_size = completions.iter().fold(1, |m, x| max(m, x.chars().count()));
-        let cols = max(1, (w as usize / (max_word_size)));
+        let cols = max(1, w as usize / max_word_size);
         let col_width = 2 + w as usize / cols;
         let cols = max(1, w as usize / col_width);
 
@@ -572,7 +572,7 @@ impl<'a, W: Write> Editor<'a, W> {
         if self.show_autosuggestions {
             {
                 let autosuggestion = self.current_autosuggestion().cloned();
-                let mut buf = self.current_buffer_mut();
+                let buf = self.current_buffer_mut();
                 if let Some(x) = autosuggestion {
                     buf.insert_from_buffer(&x);
                 }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -88,21 +88,21 @@ pub struct Editor<'a, W: Write> {
 }
 
 macro_rules! cur_buf_mut {
-    ($s:expr) => {
+    ($s: expr) => {
         match $s.cur_history_loc {
             Some(i) => &mut $s.context.history[i],
             _ => &mut $s.new_buf,
         }
-    }
+    };
 }
 
 macro_rules! cur_buf {
-    ($s:expr) => {
+    ($s: expr) => {
         match $s.cur_history_loc {
             Some(i) => &$s.context.history[i],
             _ => &$s.new_buf,
         }
-    }
+    };
 }
 
 impl<'a, W: Write> Editor<'a, W> {
@@ -727,8 +727,8 @@ impl<'a, W: Write> Editor<'a, W> {
 
         // Now that we are on the right line, we must move the term cursor left or right
         // to match the true cursor.
-        let cursor_col_diff = new_total_width as isize - new_total_width_to_cursor as isize -
-            cursor_line_diff * w as isize;
+        let cursor_col_diff = new_total_width as isize - new_total_width_to_cursor as isize
+            - cursor_line_diff * w as isize;
         if cursor_col_diff > 0 {
             try!(write!(self.out, "{}", cursor::Left(cursor_col_diff as u16)));
         } else if cursor_col_diff < 0 {

--- a/src/history.rs
+++ b/src/history.rs
@@ -289,7 +289,7 @@ fn write_to_disk(max_file_size: usize, new_item: &Buffer, file_name: &str) -> io
 
 fn move_file_contents_backward(file: &mut File, distance: u64) -> io::Result<()> {
     let mut total_read = 0;
-    let mut buffer = [0u8, 4096];
+    let mut buffer = [0u8; 4096];
 
     file.seek(SeekFrom::Start(distance))?;
     

--- a/src/history.rs
+++ b/src/history.rs
@@ -215,10 +215,6 @@ fn write_to_disk(max_file_size: usize, new_item: &Buffer, file_name: &str) -> io
         .write(true)
         .create(true)
         .open(file_name)?;
-
-    // The metadata contains the length of the file
-    let file_length = file.metadata().ok().map_or(0u64, |m| m.len());
-
     {
         // Count number of entries in file
         let mut num_stored = 0;

--- a/src/history.rs
+++ b/src/history.rs
@@ -271,7 +271,6 @@ fn write_to_disk(max_file_size: usize, new_item: &Buffer, file_name: &str) -> io
                 }
             }
 
-
             // Move it all back
             try!(move_file_contents_backward(&mut file, move_dist))
         }
@@ -292,7 +291,7 @@ fn move_file_contents_backward(file: &mut File, distance: u64) -> io::Result<()>
     let mut buffer = [0u8; 4096];
 
     file.seek(SeekFrom::Start(distance))?;
-    
+
     loop {
         // Read 4K of bytes all at once into the buffer.
         let read = file.read(&mut buffer)?;
@@ -303,7 +302,6 @@ fn move_file_contents_backward(file: &mut File, distance: u64) -> io::Result<()>
         }
 
         file.seek(SeekFrom::Current(-(read as i64 + distance as i64)))?;
-
 
         file.write_all(&buffer[..read])?;
         file.seek(SeekFrom::Current(distance as i64))?;

--- a/src/history.rs
+++ b/src/history.rs
@@ -273,10 +273,9 @@ fn write_to_disk(max_file_size: usize, new_item: &Buffer, file_name: &str) -> io
 
 
             // Move it all back
-            move_file_contents_backward(&mut file, move_dist);
+            try!(move_file_contents_backward(&mut file, move_dist))
         }
     };
-
 
     // Seek to end for appending
     try!(file.seek(SeekFrom::End(0)));
@@ -303,11 +302,11 @@ fn move_file_contents_backward(file: &mut File, distance: u64) -> io::Result<()>
             break;
         }
 
-        file.seek(SeekFrom::Current(-(read as i64 + distance as i64)));
+        file.seek(SeekFrom::Current(-(read as i64 + distance as i64)))?;
 
 
         file.write_all(&buffer[..read])?;
-        file.seek(SeekFrom::Current(distance as i64));
+        file.seek(SeekFrom::Current(distance as i64))?;
     }
 
     file.set_len(total_read)?;

--- a/src/keymap/emacs.rs
+++ b/src/keymap/emacs.rs
@@ -19,7 +19,10 @@ pub struct Emacs<'a, W: Write> {
 
 impl<'a, W: Write> Emacs<'a, W> {
     pub fn new(ed: Editor<'a, W>) -> Self {
-        Emacs { ed, last_arg_fetch_index: None }
+        Emacs {
+            ed,
+            last_arg_fetch_index: None,
+        }
     }
 
     fn handle_ctrl_key(&mut self, c: char) -> io::Result<()> {
@@ -68,7 +71,9 @@ impl<'a, W: Write> Emacs<'a, W> {
         let history_index = match self.last_arg_fetch_index {
             Some(0) => return Ok(()),
             Some(x) => x - 1,
-            None => self.ed.current_history_location().unwrap_or(self.ed.context().history.len() - 1),
+            None => self.ed
+                .current_history_location()
+                .unwrap_or(self.ed.context().history.len() - 1),
         };
 
         // If did a last arg fetch just before this, we need to delete it so it can be replaced by
@@ -96,7 +101,7 @@ impl<'a, W: Write> Emacs<'a, W> {
 impl<'a, W: Write> KeyMap<'a, W, Emacs<'a, W>> for Emacs<'a, W> {
     fn handle_key_core(&mut self, key: Key) -> io::Result<()> {
         match key {
-            Key::Alt('.') => {},
+            Key::Alt('.') => {}
             _ => self.last_arg_fetch_index = None,
         }
 
@@ -117,11 +122,11 @@ impl<'a, W: Write> KeyMap<'a, W, Emacs<'a, W>> for Emacs<'a, W> {
         }
     }
 
-    fn editor_mut(&mut self) ->  &mut Editor<'a, W> {
+    fn editor_mut(&mut self) -> &mut Editor<'a, W> {
         &mut self.ed
     }
 
-    fn editor(&self) ->  &Editor<'a, W> {
+    fn editor(&self) -> &Editor<'a, W> {
         &self.ed
     }
 }
@@ -142,26 +147,22 @@ fn emacs_move_word<W: Write>(ed: &mut Editor<W>, direction: EmacsMoveDir) -> io:
     let (words, pos) = ed.get_words_and_cursor_position();
 
     let word_index = match pos {
-        CursorPosition::InWord(i) => {
-            Some(i)
-        },
+        CursorPosition::InWord(i) => Some(i),
         CursorPosition::OnWordLeftEdge(mut i) => {
             if i > 0 && direction == EmacsMoveDir::Left {
                 i -= 1;
             }
             Some(i)
-        },
+        }
         CursorPosition::OnWordRightEdge(mut i) => {
             if i < words.len() - 1 && direction == EmacsMoveDir::Right {
                 i += 1;
             }
             Some(i)
-        },
-        CursorPosition::InSpace(left, right) => {
-            match direction {
-                EmacsMoveDir::Left => left,
-                EmacsMoveDir::Right => right,
-            }
+        }
+        CursorPosition::InSpace(left, right) => match direction {
+            EmacsMoveDir::Left => left,
+            EmacsMoveDir::Right => right,
         },
     };
 
@@ -190,13 +191,14 @@ mod tests {
     use std::io::Write;
 
     macro_rules! simulate_keys {
-        ($keymap:ident, $keys:expr) => {{
+        ($keymap: ident, $keys: expr) => {{
             simulate_keys(&mut $keymap, $keys.into_iter())
-        }}
+        }};
     }
 
     fn simulate_keys<'a, 'b, W: Write, T, M: KeyMap<'a, W, T>, I>(keymap: &mut M, keys: I) -> bool
-        where I: Iterator<Item = &'b Key>
+    where
+        I: Iterator<Item = &'b Key>,
     {
         for k in keys {
             if keymap.handle_key(*k, &mut |_| {}).unwrap() {
@@ -243,7 +245,9 @@ mod tests {
         let out = Vec::new();
         let ed = Editor::new(out, "prompt".to_owned(), &mut context).unwrap();
         let mut map = Emacs::new(ed);
-        map.editor_mut().insert_str_after_cursor("abc def ghi").unwrap();
+        map.editor_mut()
+            .insert_str_after_cursor("abc def ghi")
+            .unwrap();
         assert_eq!(map.ed.cursor(), 11);
 
         simulate_keys!(map, [Key::Alt('b')]);

--- a/src/keymap/mod.rs
+++ b/src/keymap/mod.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Write, ErrorKind};
+use std::io::{self, ErrorKind, Write};
 use termion::event::Key;
 use Editor;
 use event::*;
@@ -37,8 +37,10 @@ pub trait KeyMap<'a, W: Write, T>: From<T> {
             Key::Ctrl('f') if self.editor().is_currently_showing_autosuggestion() => {
                 try!(self.editor_mut().accept_autosuggestion());
             }
-            Key::Right if self.editor().is_currently_showing_autosuggestion() &&
-                          self.editor().cursor_is_at_end_of_line() => {
+            Key::Right
+                if self.editor().is_currently_showing_autosuggestion()
+                    && self.editor().cursor_is_at_end_of_line() =>
+            {
                 try!(self.editor_mut().accept_autosuggestion());
             }
             _ => {
@@ -74,9 +76,7 @@ mod tests {
 
     impl<'a, W: Write> TestKeyMap<'a, W> {
         pub fn new(ed: Editor<'a, W>) -> Self {
-            TestKeyMap {
-                ed: ed,
-            }
+            TestKeyMap { ed: ed }
         }
     }
 
@@ -85,11 +85,11 @@ mod tests {
             Ok(())
         }
 
-        fn editor_mut(&mut self) ->  &mut Editor<'a, W> {
+        fn editor_mut(&mut self) -> &mut Editor<'a, W> {
             &mut self.ed
         }
 
-        fn editor(&self) ->  &Editor<'a, W> {
+        fn editor(&self) -> &Editor<'a, W> {
             &self.ed
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,7 @@ fn main() {
     }
 
     loop {
-        let res = con.read_line("[prompt]$ ",
-                                &mut |Event { editor, kind }| {
+        let res = con.read_line("[prompt]$ ", &mut |Event { editor, kind }| {
             if let EventKind::BeforeComplete = kind {
                 let (_, pos) = editor.get_words_and_cursor_position();
 
@@ -83,11 +82,10 @@ fn main() {
                         // are written before exiting.
                         con.history.commit_history();
                         panic!("error: {:?}", e)
-                    },
+                    }
                 }
             }
         }
-
     }
 
     // Ensure that all writes to the history file are written before exiting.

--- a/src/test.rs
+++ b/src/test.rs
@@ -3,33 +3,36 @@ use context;
 
 use std::env;
 use std::fs;
-use std::io::{BufReader, BufRead, Write};
+use std::io::{BufRead, BufReader, Write};
 
 fn assert_cursor_pos(s: &str, cursor: usize, expected_pos: CursorPosition) {
     let buf = Buffer::from(s.to_owned());
     let words = context::get_buffer_words(&buf);
     let pos = CursorPosition::get(cursor, &words[..]);
-    assert!(expected_pos == pos,
-            format!("buffer: {:?}, cursor: {}, expected pos: {:?}, pos: {:?}",
-                    s,
-                    cursor,
-                    expected_pos,
-                    pos));
+    assert!(
+        expected_pos == pos,
+        format!(
+            "buffer: {:?}, cursor: {}, expected pos: {:?}, pos: {:?}",
+            s, cursor, expected_pos, pos
+        )
+    );
 }
 
 #[test]
 fn test_get_cursor_position() {
     use CursorPosition::*;
 
-    let tests = &[("hi", 0, OnWordLeftEdge(0)),
-                  ("hi", 1, InWord(0)),
-                  ("hi", 2, OnWordRightEdge(0)),
-                  ("abc  abc", 4, InSpace(Some(0), Some(1))),
-                  ("abc  abc", 5, OnWordLeftEdge(1)),
-                  ("abc  abc", 6, InWord(1)),
-                  ("abc  abc", 8, OnWordRightEdge(1)),
-                  (" a", 0, InSpace(None, Some(0))),
-                  ("a ", 2, InSpace(Some(0), None))];
+    let tests = &[
+        ("hi", 0, OnWordLeftEdge(0)),
+        ("hi", 1, InWord(0)),
+        ("hi", 2, OnWordRightEdge(0)),
+        ("abc  abc", 4, InSpace(Some(0), Some(1))),
+        ("abc  abc", 5, OnWordLeftEdge(1)),
+        ("abc  abc", 6, InWord(1)),
+        ("abc  abc", 8, OnWordRightEdge(1)),
+        (" a", 0, InSpace(None, Some(0))),
+        ("a ", 2, InSpace(Some(0), None)),
+    ];
 
     for t in tests {
         assert_cursor_pos(t.0, t.1, t.2);
@@ -47,16 +50,20 @@ fn assert_buffer_actions(start: &str, expected: &str, actions: &[Action]) {
 
 #[test]
 fn test_buffer_actions() {
-    assert_buffer_actions("",
-                          "h",
-                          &[Action::Insert {
-                                start: 0,
-                                text: "hi".chars().collect(),
-                            },
-                            Action::Remove {
-                                start: 1,
-                                text: ".".chars().collect(),
-                            }]);
+    assert_buffer_actions(
+        "",
+        "h",
+        &[
+            Action::Insert {
+                start: 0,
+                text: "hi".chars().collect(),
+            },
+            Action::Remove {
+                start: 1,
+                text: ".".chars().collect(),
+            },
+        ],
+    );
 }
 
 #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -66,13 +66,13 @@ pub fn remove_codes(input: &str) -> Cow<str> {
                     _ => s = AnsiState::Norm,
                 },
                 AnsiState::Csi => match c {
-                    'A' ... 'Z' | 'a' ... 'z' => s = AnsiState::Norm,
+                    'A'...'Z' | 'a'...'z' => s = AnsiState::Norm,
                     _ => (),
                 },
                 AnsiState::Osc => match c {
                     '\x07' => s = AnsiState::Norm,
                     _ => (),
-                }
+                },
             }
         }
 


### PR DESCRIPTION
This pull request fixes the various compiler warnings generated when compiling `master`:
(Unused variable/mut, unused Results, Overflow)

The diffs in the first 3 commits will be more useful - the last just runs rustfmt on the codebase

fixes #81 