### PR TITLE
Fix buffer size.

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -294,7 +294,7 @@ fn write_to_disk(max_file_size: usize, new_item: &Buffer, file_name: &str) -> io
 
 fn move_file_contents_backward(file: &mut File, distance: u64) -> io::Result<()> {
     let mut total_read = 0;
-    let mut buffer = [0u8, 4096];
+    let mut buffer = [0u8; 4096];
 
     file.seek(SeekFrom::Start(distance))?;
     


### PR DESCRIPTION
Actually read 4096 bytes at once, instead of only 2 bytes.