### PR TITLE
Fixed compilation issues

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -65,7 +65,7 @@ impl<'a> From<&'a str> for Buffer {
 impl fmt::Display for Buffer {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for &c in &self.data {
-            try!(f.write_char(c));
+            f.write_char(c)?;
         }
         Ok(())
     }
@@ -256,7 +256,7 @@ impl Buffer {
         where W: Write
     {
         let string: String = self.data.iter().cloned().collect();
-        try!(out.write(string.as_bytes()));
+        out.write(string.as_bytes())?;
 
         Ok(())
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -92,9 +92,10 @@ impl Context {
         buffer: B,
     ) -> io::Result<String> {
         let res = {
+            let bindings = self.key_bindings;
             let stdout = stdout().into_raw_mode().unwrap();
             let ed = try!(Editor::new_with_init_buffer(stdout, prompt, self, buffer));
-            match self.key_bindings {
+            match bindings {
                 KeyBindings::Emacs => Self::handle_keys(keymap::Emacs::new(ed), handler),
                 KeyBindings::Vi => Self::handle_keys(keymap::Vi::new(ed), handler),
             }

--- a/src/event.rs
+++ b/src/event.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 use termion::event::Key;
 use Editor;
 
-pub type EventHandler<'a, W> = FnMut(Event<W>) + 'a;
+pub type EventHandler<'a, W> = dyn FnMut(Event<W>) + 'a;
 
 pub struct Event<'a, 'out: 'a, W: Write + 'a> {
     pub editor: &'a mut Editor<'out, W>,

--- a/src/history.rs
+++ b/src/history.rs
@@ -294,7 +294,7 @@ fn write_to_disk(max_file_size: usize, new_item: &Buffer, file_name: &str) -> io
 
 fn move_file_contents_backward(file: &mut File, distance: u64) -> io::Result<()> {
     let mut total_read = 0;
-    let mut buffer = [0u8, 4096];
+    let mut buffer = [0u8; 4096];
 
     file.seek(SeekFrom::Start(distance))?;
     

--- a/src/keymap/emacs.rs
+++ b/src/keymap/emacs.rs
@@ -36,7 +36,7 @@ impl<'a, W: Write> Emacs<'a, W> {
             'k' => self.ed.delete_all_after_cursor(),
             'w' => self.ed.delete_word_before_cursor(true),
             'x' => {
-                try!(self.ed.undo());
+                self.ed.undo()?;
                 Ok(())
             }
             _ => Ok(()),
@@ -51,7 +51,7 @@ impl<'a, W: Write> Emacs<'a, W> {
             'f' => emacs_move_word(&mut self.ed, EmacsMoveDir::Right),
             'b' => emacs_move_word(&mut self.ed, EmacsMoveDir::Left),
             'r' => {
-                try!(self.ed.revert());
+                self.ed.revert()?;
                 Ok(())
             }
             '.' => self.handle_last_arg_fetch(),
@@ -191,7 +191,7 @@ mod tests {
 
     macro_rules! simulate_keys {
         ($keymap:ident, $keys:expr) => {{
-            simulate_keys(&mut $keymap, $keys.into_iter())
+            simulate_keys(&mut $keymap, $keys.iter())
         }}
     }
 

--- a/src/keymap/mod.rs
+++ b/src/keymap/mod.rs
@@ -22,34 +22,34 @@ pub trait KeyMap<'a, W: Write, T>: From<T> {
 
         match key {
             Key::Ctrl('c') => {
-                try!(self.editor_mut().handle_newline());
+                self.editor_mut().handle_newline()?;
                 return Err(io::Error::new(ErrorKind::Interrupted, "ctrl-c"));
             }
             // if the current buffer is empty, treat ctrl-d as eof
             Key::Ctrl('d') if is_empty => {
-                try!(self.editor_mut().handle_newline());
+                self.editor_mut().handle_newline()?;
                 return Err(io::Error::new(ErrorKind::UnexpectedEof, "ctrl-d"));
             }
-            Key::Char('\t') => try!(self.editor_mut().complete(handler)),
+            Key::Char('\t') => self.editor_mut().complete(handler)?,
             Key::Char('\n') => {
-                done = try!(self.editor_mut().handle_newline());
+                done = self.editor_mut().handle_newline()?;
             }
             Key::Ctrl('f') if self.editor().is_currently_showing_autosuggestion() => {
-                try!(self.editor_mut().accept_autosuggestion());
+                self.editor_mut().accept_autosuggestion()?;
             }
             Key::Right if self.editor().is_currently_showing_autosuggestion() &&
                           self.editor().cursor_is_at_end_of_line() => {
-                try!(self.editor_mut().accept_autosuggestion());
+                self.editor_mut().accept_autosuggestion()?;
             }
             _ => {
-                try!(self.handle_key_core(key));
+                self.handle_key_core(key)?;
                 self.editor_mut().skip_completions_hint();
             }
         };
 
         handler(Event::new(self.editor_mut(), EventKind::AfterKey(key)));
 
-        try!(self.editor_mut().flush());
+        self.editor_mut().flush()?;
 
         Ok(done)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 extern crate liner;
 extern crate termion;
 
-use std::mem::replace;
 use std::env::{args, current_dir};
 use std::io;
 
@@ -38,9 +37,9 @@ fn main() {
 
                 if filename {
                     let completer = FilenameCompleter::new(Some(current_dir().unwrap()));
-                    replace(&mut editor.context().completer, Some(Box::new(completer)));
+                    editor.context().completer = Some(Box::new(completer));
                 } else {
-                    replace(&mut editor.context().completer, None);
+                    editor.context().completer = None;
                 }
             }
         });

--- a/src/test.rs
+++ b/src/test.rs
@@ -9,12 +9,12 @@ fn assert_cursor_pos(s: &str, cursor: usize, expected_pos: CursorPosition) {
     let buf = Buffer::from(s.to_owned());
     let words = context::get_buffer_words(&buf);
     let pos = CursorPosition::get(cursor, &words[..]);
-    assert!(expected_pos == pos,
-            format!("buffer: {:?}, cursor: {}, expected pos: {:?}, pos: {:?}",
-                    s,
-                    cursor,
-                    expected_pos,
-                    pos));
+    assert_eq!(expected_pos, pos,
+                "buffer: {:?}, cursor: {}, expected pos: {:?}, pos: {:?}",
+                s,
+                cursor,
+                expected_pos,
+                pos);
 }
 
 #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -66,7 +66,7 @@ pub fn remove_codes(input: &str) -> Cow<str> {
                     _ => s = AnsiState::Norm,
                 },
                 AnsiState::Csi => match c {
-                    'A' ... 'Z' | 'a' ... 'z' => s = AnsiState::Norm,
+                    'A' ..= 'Z' | 'a' ..= 'z' => s = AnsiState::Norm,
                     _ => (),
                 },
                 AnsiState::Osc => match c {


### PR DESCRIPTION
In `src/context.rs`, `Context::read_line_with_init_buffer` had a borrow bug where `self.key_bindings` was read after it was borrowed by `Editor::new_with_init_buffer`. I fixed the issue by copying the attribute to a new variable beforehand. Fixes #96.

In `src/history.rs:297:29`, you typed `[0u8, 4096]`, when you meant to write `[0u8; 4096]`, and thus Rust thought you were trying to create a two-byte array with the contents `[0, 4096]`, as opposed to a 4096-byte array with zeroed contents. Fixes #84.
